### PR TITLE
Remove all listeners in no specific handler specified

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,10 @@ export class EventEmitterMixin {
   off(name, fn) {
     let listeners = this._getListeners(name);
     if (!listeners) return;
+    if (!fn) {
+      listeners.splice(0, listeners.length);
+      return;
+    }
     let index = listeners.indexOf(fn);
     if (index !== -1) listeners.splice(index, 1);
   }

--- a/test.js
+++ b/test.js
@@ -122,5 +122,26 @@ describe('EventEmitter', function() {
       person.emit('event');
       assert.isFalse(hasBeenCalled);
     });
+    it('should remove all listeners in no specific handler specified', function() {
+      @EventEmitter class Person {}
+      let person = new Person();
+      let hasBeenCalled1 = false;
+      let hasBeenCalled2 = false;
+      person.on('event', function() {
+        hasBeenCalled1 = true;
+      });
+      person.on('event', function() {
+        hasBeenCalled2 = true;
+      });
+      person.emit('event');
+      assert.isTrue(hasBeenCalled1);
+      assert.isTrue(hasBeenCalled2);
+      person.off('event');
+      hasBeenCalled1 = false;
+      hasBeenCalled2 = false;
+      person.emit('event');
+      assert.isFalse(hasBeenCalled1);
+      assert.isFalse(hasBeenCalled2);
+    });
   });
 });


### PR DESCRIPTION
Adds a shorthand to remove all listeners for an event.

If you specify no specific handler, all listeners will be removed.
